### PR TITLE
Works with units >= 2.4.1

### DIFF
--- a/units-attoparsec.cabal
+++ b/units-attoparsec.cabal
@@ -25,13 +25,13 @@ source-repository head
   location: https://github.com/jcristovao/units-attoparsec.git
 
 library
-  build-depends:      
+  build-depends:
         base       >= 4.7   && < 5
-      , units      >= 2.3   && < 2.4
+      , units      ==2.3.*  || (>= 2.4.1 && < 2.5)
       , units-defs >= 2.0   && < 2.1
       , text       >= 1.1   && < 1.4
       , attoparsec >= 0.11  && < 0.14
-      , template-haskell >= 2.8 && < 2.11
+      , template-haskell >= 2.8 && < 2.12
 
   exposed-modules:
     Data.Units.SI.Prefixes.Attoparsec.Text,


### PR DESCRIPTION
Works with the (unreleased) units 2.4.1 after [this PR](https://github.com/goldfirere/units/pull/56).
